### PR TITLE
Don't block Egress since it's hard to then turn it back on just for kube-apiserver

### DIFF
--- a/apps/container-linux-update-operator/network-policy.yml
+++ b/apps/container-linux-update-operator/network-policy.yml
@@ -7,4 +7,3 @@ spec:
   podSelector: {}
   policyTypes:
   - Ingress
-  - Egress


### PR DESCRIPTION
Those pods are magic.