### PR TITLE
DEVOPS-2336 - Upgrade cert-manager to v0.10.0

### DIFF
--- a/apps/cert-manager/cert-manager.yml
+++ b/apps/cert-manager/cert-manager.yml
@@ -347,7 +347,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.9.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.10.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=2


### PR DESCRIPTION
After update need follow steps from after https://cert-manager.io/docs/installation/upgrading/upgrading-0.9-0.10/